### PR TITLE
Added customizable consumerWindowSize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 .classpath
 .settings
 .project
+.idea
+*.iml
 bin
 *~

--- a/src/main/java/com/mercateo/spring/boot/starter/hornetq/cluster/ClusteredHornetQProperties.java
+++ b/src/main/java/com/mercateo/spring/boot/starter/hornetq/cluster/ClusteredHornetQProperties.java
@@ -23,4 +23,6 @@ public class ClusteredHornetQProperties extends HornetQProperties {
     private String user;
 
     private String password;
+
+    private Integer windowSize;
 }

--- a/src/main/java/org/springframework/boot/autoconfigure/jms/hornetq/ClusteredHornetQConnectionFactoryFactory.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/jms/hornetq/ClusteredHornetQConnectionFactoryFactory.java
@@ -3,14 +3,13 @@ package org.springframework.boot.autoconfigure.jms.hornetq;
 import org.hornetq.api.core.TransportConfiguration;
 import org.hornetq.jms.client.HornetQConnectionFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.boot.autoconfigure.jms.hornetq.HornetQConnectionFactoryFactory;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.mercateo.spring.boot.starter.hornetq.cluster.ClusteredHornetQProperties;
 import com.mercateo.spring.boot.starter.hornetq.cluster.HornetQConnectionFactories;
-
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Factory able to create a factory that creates {@link TransportConfiguration}s
@@ -27,24 +26,38 @@ public class ClusteredHornetQConnectionFactoryFactory extends HornetQConnectionF
 
     private final String authorities;
 
+    private final Integer windowSize;
+
     public ClusteredHornetQConnectionFactoryFactory(@NonNull ListableBeanFactory beanFactory,
             @NonNull ClusteredHornetQProperties properties) {
         super(beanFactory, properties);
         authorities = properties.getAuthorities();
+        windowSize = properties.getWindowSize();
     }
 
     @Override
     public <T extends HornetQConnectionFactory> T createConnectionFactory(
             @NonNull Class<T> factoryClass) {
+
+        T connectionFactory;
+
         if (authorities == null) {
-            return callSuperCreateConnectionFactory(factoryClass);
+            connectionFactory = callSuperCreateConnectionFactory(factoryClass);
+        } else {
+            try {
+                log.info("creating native connection factory from spring.hornetq.authorities");
+                connectionFactory = HornetQConnectionFactories.fromAuthorities(factoryClass,
+                        authorities);
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to create HornetQConnectionFactory", e);
+            }
         }
-        try {
-            log.info("creating native connection factory from spring.hornetq.authorities");
-            return HornetQConnectionFactories.fromAuthorities(factoryClass, authorities);
-        } catch (Exception e) {
-            throw new IllegalStateException("Unable to create HornetQConnectionFactory", e);
+
+        if (windowSize != null) {
+            connectionFactory.setConsumerWindowSize(windowSize);
         }
+
+        return connectionFactory;
     }
 
     @VisibleForTesting

--- a/src/test/java/org/springframework/boot/autoconfigure/jms/hornetq/ClusteredHornetQConnectionFactoryFactory0Test.java
+++ b/src/test/java/org/springframework/boot/autoconfigure/jms/hornetq/ClusteredHornetQConnectionFactoryFactory0Test.java
@@ -1,6 +1,6 @@
 package org.springframework.boot.autoconfigure.jms.hornetq;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -8,10 +8,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.hornetq.api.core.TransportConfiguration;
+import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.jms.client.HornetQConnectionFactory;
 import org.junit.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.boot.autoconfigure.jms.hornetq.ClusteredHornetQConnectionFactoryFactory;
 
 import com.mercateo.spring.boot.starter.hornetq.cluster.ClusteredHornetQProperties;
 
@@ -40,22 +40,51 @@ public class ClusteredHornetQConnectionFactoryFactory0Test {
     }
 
     @Test
-    public void mustFallbacktoSuperclassBecauseNoAuthoritiesConfigured() throws Exception {
+    public void mustFallbacktoSuperclassBecauseNoAuthoritiesConfiguredNoWindowSize() throws Exception {
         ClusteredHornetQProperties noAuthorities = new ClusteredHornetQProperties();
         ClusteredHornetQConnectionFactoryFactory uut = spy(
                 new ClusteredHornetQConnectionFactoryFactory(mockBeanFactory, noAuthorities));
-        uut.createConnectionFactory(factoryClass);
+        HornetQConnectionFactory connectionFactory = uut.createConnectionFactory(factoryClass);
         verify(uut, times(1)).callSuperCreateConnectionFactory(factoryClass);
+        assertEquals(HornetQClient.DEFAULT_CONSUMER_WINDOW_SIZE, connectionFactory
+                .getConsumerWindowSize());
     }
 
     @Test
-    public void mustNotFallbacktoSuperclassBecauseTwoAuthoritiesConfigured() throws Exception {
+    public void mustNotFallbacktoSuperclassBecauseTwoAuthoritiesConfiguredNoWindowSize() throws Exception {
         ClusteredHornetQProperties twoAuthorities = new ClusteredHornetQProperties();
         twoAuthorities.setAuthorities("foo:8888,bar:9999");
         ClusteredHornetQConnectionFactoryFactory uut = spy(
                 new ClusteredHornetQConnectionFactoryFactory(mockBeanFactory, twoAuthorities));
-        uut.createConnectionFactory(factoryClass);
+        HornetQConnectionFactory connectionFactory = uut.createConnectionFactory(factoryClass);
         verify(uut, never()).callSuperCreateConnectionFactory(factoryClass);
+        assertEquals(HornetQClient.DEFAULT_CONSUMER_WINDOW_SIZE, connectionFactory
+                .getConsumerWindowSize());
+    }
+
+    @Test
+    public void mustFallbacktoSuperclassBecauseNoAuthoritiesConfiguredWithGivenWindowSize() throws Exception {
+        ClusteredHornetQProperties noAuthorities = new ClusteredHornetQProperties();
+        noAuthorities.setWindowSize(0);
+        ClusteredHornetQConnectionFactoryFactory uut = spy(
+                new ClusteredHornetQConnectionFactoryFactory(mockBeanFactory, noAuthorities));
+        HornetQConnectionFactory connectionFactory = uut.createConnectionFactory(factoryClass);
+        verify(uut, times(1)).callSuperCreateConnectionFactory(factoryClass);
+        assertEquals(0, connectionFactory
+                .getConsumerWindowSize());
+    }
+
+    @Test
+    public void mustNotFallbacktoSuperclassBecauseTwoAuthoritiesConfiguredWithGivenWindowSize() throws Exception {
+        ClusteredHornetQProperties twoAuthorities = new ClusteredHornetQProperties();
+        twoAuthorities.setAuthorities("foo:8888,bar:9999");
+        twoAuthorities.setWindowSize(0);
+        ClusteredHornetQConnectionFactoryFactory uut = spy(
+                new ClusteredHornetQConnectionFactoryFactory(mockBeanFactory, twoAuthorities));
+        HornetQConnectionFactory connectionFactory = uut.createConnectionFactory(factoryClass);
+        verify(uut, never()).callSuperCreateConnectionFactory(factoryClass);
+        assertEquals(0, connectionFactory
+                .getConsumerWindowSize());
     }
 
     @Test


### PR DESCRIPTION
Wir bräuchten im core-Team eine konfigurierbare consumerWindowSize, damit lang laufende Consumer nicht unsere Applikation blockieren. Ich habe deshalb eine neue Property (windowSize) hinzugefügt. Wenn die Property nicht gesetzt ist, verhält sich der Starter wie vorher.
