### PR TITLE
BugFix: Return only one ConnectionFactory

### DIFF
--- a/src/main/java/com/mercateo/spring/boot/starter/hornetq/cluster/UserCredentialsConnectionFactoryAdapterConfiguration.java
+++ b/src/main/java/com/mercateo/spring/boot/starter/hornetq/cluster/UserCredentialsConnectionFactoryAdapterConfiguration.java
@@ -1,9 +1,9 @@
 package com.mercateo.spring.boot.starter.hornetq.cluster;
 
-import javax.jms.ConnectionFactory;
-
 import org.hornetq.jms.client.HornetQConnectionFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.jms.hornetq.ClusteredHornetQConnectionFactoryFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -13,27 +13,29 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Configuration class proving bean for
- * {@link UserCredentialsConnectionFactoryAdapter} wrapping an available
+ * Configuration class providing bean for
+ * {@link UserCredentialsConnectionFactoryAdapter} wrapping a
  * {@link HornetQConnectionFactory} instance, applying the given user
  * credentials to every standard <code>createConnection()</code> call.
  * 
  * @author CFM
  */
+@ConditionalOnProperty("spring.hornetq.user")
 @Slf4j
 @Configuration
-@ConditionalOnBean(ConnectionFactory.class)
 public class UserCredentialsConnectionFactoryAdapterConfiguration {
-    @Bean
+
     @Primary
-    UserCredentialsConnectionFactoryAdapter createUserCredentialsFactoryAdapter(
-            @NonNull HornetQConnectionFactory hornetqFactory,
+    @Bean
+    UserCredentialsConnectionFactoryAdapter jmsConnectionFactory(
+            @NonNull ListableBeanFactory beanFactory,
             @NonNull ClusteredHornetQProperties properties) {
         log.info("creating user credentials wrapper for available HornetQConnectionFactory");
         UserCredentialsConnectionFactoryAdapter secureFactory = new UserCredentialsConnectionFactoryAdapter();
         secureFactory.setUsername(properties.getUser());
         secureFactory.setPassword(properties.getPassword());
-        secureFactory.setTargetConnectionFactory(hornetqFactory);
+        secureFactory.setTargetConnectionFactory(new ClusteredHornetQConnectionFactoryFactory(
+                beanFactory, properties).createConnectionFactory(HornetQConnectionFactory.class));
         return secureFactory;
     }
 }

--- a/src/main/java/org/springframework/boot/autoconfigure/jms/hornetq/ClusteredHornetQAutoConfiguration.java
+++ b/src/main/java/org/springframework/boot/autoconfigure/jms/hornetq/ClusteredHornetQAutoConfiguration.java
@@ -31,7 +31,6 @@ import com.mercateo.spring.boot.starter.hornetq.cluster.UserCredentialsConnectio
 @ConditionalOnMissingBean(ConnectionFactory.class)
 @EnableConfigurationProperties(ClusteredHornetQProperties.class)
 @Import({ HornetQEmbeddedServerConfiguration.class,
-        /* HornetQXAConnectionFactoryConfiguration.class, */
         ClusteredHornetQConnectionFactoryConfiguration.class,
         UserCredentialsConnectionFactoryAdapterConfiguration.class })
 public class ClusteredHornetQAutoConfiguration {


### PR DESCRIPTION
- UserCredentialsConnectionFactory replaces HornetQConnectionFactory, if a user is configured.
- HornetQConnectionFactory will be generated, when credentials are not provided
